### PR TITLE
feat: Add Credit Card Portfolio Management series

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,6 +108,7 @@ feed_show_tags: true
 home_series:
   - "Book Sharing"
   - "A/B Testing"
+  - "Credit Card Portfolio Management 101"
 
 # Add a search button to the navbar
 post_search: true

--- a/_posts/credit-card-portfolio/2026-04-02-1-product-overview.md
+++ b/_posts/credit-card-portfolio/2026-04-02-1-product-overview.md
@@ -1,0 +1,96 @@
+---
+layout: post
+title: "The Credit Card Product: Economics & Ecosystem"
+subtitle: "How credit cards work, who profits, and why the risk is two-sided"
+tags: [credit-card, portfolio-management]
+comments: true
+math: true
+series: "Credit Card Portfolio Management 101"
+series_part: 1
+---
+
+Before you can manage a credit card portfolio, you need to understand what you are actually managing: a financial product that sits at the intersection of consumer credit, payment infrastructure, and multi-party economics.
+
+## How a Credit Card Works
+
+A credit card is a revolving credit facility. The bank extends a credit limit, the cardholder spends against it, and the balance is billed monthly.
+
+Three mechanics drive the economics:
+
+**Billing cycle** — typically 30 days. All transactions within the cycle appear on a single statement.
+
+**Grace period** — the window between statement close and payment due date, usually 21–25 days. If the cardholder pays the full statement balance before the due date, no interest is charged.
+
+**Interest accrual** — if the cardholder carries a balance past the due date, the bank charges interest on the average daily balance (ADB) at the Annual Percentage Rate (APR):
+
+$$
+\text{Monthly Interest} = \text{ADB} \times \frac{\text{APR}}{365} \times \text{Days in Cycle}
+$$
+
+The grace period is the issuer's strategic lever: it keeps transactors happy (they never pay interest) while generating substantial revenue from revolvers who carry balances.
+
+## The Four-Party Ecosystem
+
+Every credit card transaction passes through four parties:
+
+| Party | Role |
+| --- | --- |
+| **Cardholder** | Spends against a credit limit; repays (or revolves) the balance |
+| **Issuer** | The bank that underwrites and funds the credit; owns the customer relationship |
+| **Network** | Visa, Mastercard, Amex — sets rules, routes transactions, guarantees settlement |
+| **Merchant** | Accepts payment; pays a fee on each transaction |
+
+The money flow on a $100 purchase looks roughly like this:
+
+- Merchant receives ~$97.50 (after a ~2.5% merchant discount rate)
+- Issuer keeps ~$2.00 (interchange)
+- Network keeps ~$0.10–$0.15 (network assessment fee)
+- Acquirer keeps the remainder
+
+Amex and Discover operate as both issuer and network ("closed loop"), capturing both sides.
+
+## Issuer Revenue Model
+
+An issuer earns from four primary sources:
+
+**Interchange income** — a percentage of each purchase, paid by the acquiring bank (and ultimately passed to the merchant). Interchange rates vary by card tier, merchant category, and network. Premium rewards cards carry higher interchange (~2–3%) to fund their rewards programs.
+
+**Interest income** — the dominant revenue source. Revolvers pay APR on their carried balance. With average APRs in the 20–28% range, even modest revolving balances generate significant yield.
+
+$$
+\text{Net Interest Income} = \text{Average Revolving Balance} \times (\text{APR} - \text{Cost of Funds})
+$$
+
+**Fee income** — annual fees, late payment fees, over-limit fees, cash advance fees, foreign transaction fees.
+
+**Other income** — co-brand partnership fees, balance transfer fees.
+
+## Issuer Cost Structure
+
+Running a card portfolio is expensive. The main cost categories:
+
+**Cost of funds** — the bank borrows money (deposits, wholesale funding) to lend to cardholders. Cost of funds is the floor below which no card can be profitable.
+
+**Credit losses** — charged-off balances that are never recovered. This is typically the largest cost item for mass-market portfolios, ranging from 3–8% of outstanding balances depending on risk appetite.
+
+**Fraud losses** — unauthorized transactions absorbed by the issuer. Grows with transaction volume and card-not-present channels.
+
+**Servicing cost** — call center, statements, disputes, technology, compliance. Often $80–$150 per account per year.
+
+**Rewards cost** — for rewards cards, the cost of points, miles, and cashback. Can reach 1–2% of spend, and must be fully covered by interchange income.
+
+**Acquisition cost** — marketing, underwriting, card production, and onboarding. Typically $50–$200 per new account.
+
+## The Two-Sided Risk Problem
+
+Credit cards are unusual because the issuer faces two distinct and partially conflicting risks:
+
+**Acquisition risk** — approving too few good customers means leaving profitable relationships on the table. Approving too many bad customers means absorbing credit losses.
+
+**Credit risk** — a customer who looks good at application may deteriorate after booking. Income shocks, over-leverage, or behavioral shifts can turn a transactor into a defaulter within months.
+
+This creates a fundamental tension: the strategies that maximize approval rates tend to increase credit losses, and the strategies that minimize credit losses tend to suppress growth.
+
+Managing this tension — across the full customer lifecycle, at the portfolio level — is what credit card portfolio management is about.
+
+In Part 2, you will learn how to classify the customers already in your portfolio: who they are, how they behave, and what they are actually worth.

--- a/_posts/credit-card-portfolio/2026-04-02-2-customer-segmentation.md
+++ b/_posts/credit-card-portfolio/2026-04-02-2-customer-segmentation.md
@@ -1,0 +1,110 @@
+---
+layout: post
+title: "Customer Segmentation: Who's in Your Portfolio?"
+subtitle: "Transactors, revolvers, hibernators, and defaulters — the four archetypes that shape portfolio economics"
+tags: [credit-card, portfolio-management]
+comments: true
+math: true
+series: "Credit Card Portfolio Management 101"
+series_part: 2
+---
+
+Not all cardholders behave the same way. A portfolio that looks healthy in aggregate can contain a very different mix underneath. Understanding that mix — and how it shifts — is the foundation of effective portfolio management.
+
+## The Four Behavioral Archetypes
+
+### Transactor
+
+A transactor pays the full statement balance every cycle. They never carry revolving debt.
+
+- Generate interchange income on every purchase
+- Generate zero interest income
+- Generally low credit risk
+- High-engagement customers, often with premium cards
+
+Transactors are profitable through spend volume and interchange, but margin per dollar is thin. Issuers subsidize their rewards programs hoping transactors will occasionally revolve — or refer others who do.
+
+### Revolver
+
+A revolver carries a balance month-to-month, paying only minimum or partial payments.
+
+- Generate substantial interest income (APR × ADB)
+- Generate interchange on purchases
+- Higher credit risk than transactors
+- The primary profit engine of most mass-market portfolios
+
+The revolver segment is heterogeneous. A stable revolver with a manageable balance and consistent payments is highly profitable. A stress-revolving customer who just lost their job is a loss event waiting to happen.
+
+### Hibernator (Dormant)
+
+A hibernator holds an open account but makes little to no use of it — no or near-zero spend over an extended period (typically 3–6+ months).
+
+- Generate no interchange
+- Generate no interest income
+- Consume servicing cost
+- Represent an unactivated or lapsed relationship
+
+Hibernators are a drag on the portfolio. They occupy credit exposure (committed but undrawn limit) and generate costs. The management question is whether to reactivate them or close the accounts.
+
+### Defaulter
+
+A defaulter has stopped making payments and is trending toward charge-off.
+
+- Generate no current income
+- Are generating active losses (missed interest accruals, collection costs)
+- Will ultimately result in a write-off if not cured
+
+Some defaulters cure — they resume payments after a period of delinquency. Many do not. The goal is to identify this segment early and intervene before the loss is realized.
+
+## How to Identify Each Segment
+
+Segmentation is based on behavioral signals from account data:
+
+| Signal | Transactor | Revolver | Hibernator | Defaulter |
+| -------- | ----------- | --------- | ----------- | ---------- |
+| Payment ratio (payment / statement balance) | ≥ 100% | < 100% | N/A | 0% or missing |
+| Utilization rate | Low–Moderate | Moderate–High | Near 0% | Often high before default |
+| Days past due | 0 | 0 | 0 | 30+ DPD |
+| Spend activity | Regular | Regular | Absent or rare | Declining |
+
+**Payment ratio** is the most reliable single signal: a customer paying 100%+ of their statement balance is a transactor by definition.
+
+## Unit Economics per Segment
+
+$$
+\text{Profit per Account} = \text{Interest Income} + \text{Interchange Income} + \text{Fee Income} - \text{Credit Losses} - \text{Fraud Losses} - \text{Rewards Cost} - \text{Servicing Cost}
+$$
+
+In practice, unit economics by segment look roughly like:
+
+| Segment | Interest Income | Interchange | Credit Loss | Net Margin |
+| --------- | --------------- | ----------- | ----------- | ---------- |
+| Transactor | Low | High | Very Low | Moderate |
+| Revolver | High | Moderate | Moderate | High (if stable) |
+| Hibernator | None | None | Low | Negative |
+| Defaulter | None | None | Very High | Severely Negative |
+
+The revolver-transactor split in your portfolio is one of the most important strategic parameters. A portfolio skewed too heavily toward transactors is margin-thin. A portfolio skewed too heavily toward revolvers carries elevated loss risk.
+
+## Segment Migration
+
+Customers move between segments over time. Common migration paths:
+
+- **Transactor → Revolver**: income shock, increased spending, holiday season
+- **Revolver → Defaulter**: over-leverage, job loss, medical expense
+- **Transactor → Hibernator**: competitive offer, changed spending behavior
+- **Defaulter → Revolver (cure)**: resolved hardship, payment plan
+
+Migration matrices (also called flow-state matrices) track what percentage of each segment transitions to another segment month-over-month. A rising rate of Revolver → Defaulter migration is an early warning signal that the portfolio is deteriorating.
+
+## Portfolio Composition Health
+
+There is no universally "correct" mix — it depends on the bank's risk appetite, funding cost, and product strategy. But some benchmarks apply:
+
+- A healthy mass-market portfolio typically has 40–60% revolvers by balance
+- Dormancy rate above 20% of accounts is a utilization problem
+- Charge-off rate above 6–8% annualized on a mature portfolio signals credit quality issues
+
+Tracking segment composition over time, by vintage and product, tells you whether your portfolio is moving in the right direction — before the P&L tells you it isn't.
+
+In Part 3, you will see how these segments map onto the credit card lifecycle, and what management actions are available at each stage.

--- a/_posts/credit-card-portfolio/2026-04-02-3-lifecycle-management.md
+++ b/_posts/credit-card-portfolio/2026-04-02-3-lifecycle-management.md
@@ -1,0 +1,125 @@
+---
+layout: post
+title: "Product Lifecycle & Lifecycle Management"
+subtitle: "From underwriting to recovery — the full arc of a credit card account"
+tags: [credit-card, portfolio-management]
+comments: true
+math: true
+series: "Credit Card Portfolio Management 101"
+series_part: 3
+---
+
+A credit card account is not a static asset. It moves through distinct stages over its life, and each stage demands different management actions. Understanding the lifecycle — and having the right strategies at each point — is the operational core of portfolio management.
+
+## The Full Credit Card Lifecycle
+
+```plain
+Acquisition → Activation → Usage → Mature → At-Risk → Default → Collections / Recovery
+                                                ↑                        |
+                                         Reactivation ←── Dormancy      ↓
+                                                                   Charge-Off
+```
+
+Each stage has distinct characteristics, metrics, and levers.
+
+## Stage 1: Acquisition & Underwriting
+
+Acquisition is where the portfolio is built — and where its future risk is locked in.
+
+**Credit decisioning** determines whether an applicant is approved, at what credit limit, and at what APR. The decision engine uses:
+
+- Bureau data (credit score, tradeline history, derogatory records)
+- Application data (income, employment, existing obligations)
+- Internal behavioral data (for existing bank customers)
+
+**Risk-based pricing** calibrates APR to estimated default probability. Higher-risk applicants receive higher APRs to compensate for expected losses. This is how a portfolio can profitably serve a broad credit spectrum.
+
+The key underwriting tension: approval rate vs credit quality. Loosening criteria grows the book faster but raises future charge-offs. Tightening criteria improves quality but slows growth and may leave profitable customers to competitors.
+
+## Stage 2: Activation & Early Engagement
+
+An approved account that never activates generates no revenue and still carries servicing cost. The activation rate — the percentage of new accounts that make at least one purchase within a defined window (typically 90 days) — is a critical early health metric.
+
+Early engagement actions:
+
+- Activation incentives (bonus rewards on first purchase)
+- Onboarding communications explaining the product benefits
+- First-purchase offers to drive initial spend
+
+The first 90 days also reveal early behavioral signals. A cardholder who maxes out their limit within the first billing cycle is a very different risk profile than one building a modest spending pattern.
+
+## Stage 3: Active Usage
+
+In the active phase, the account is generating revenue through spend and, for revolvers, interest income.
+
+Key management actions:
+
+- **Spend stimulation** — category-specific offers, merchant-funded rewards, targeted campaigns to increase purchase volume
+- **Credit line management** — increase limits for high-performing accounts to capture more spend share; monitor utilization for signs of stress
+- **Product engagement** — app usage, autopay enrollment, statement delivery preferences
+
+This is the longest stage. Accounts can remain productively active for years or decades. The goal is to maximize profitable engagement while monitoring behavioral signals for early deterioration.
+
+## Stage 4: At-Risk Detection
+
+Before an account defaults, it usually shows warning signs. Early risk detection is far cheaper than late-stage collections.
+
+Warning signals:
+
+- Rising utilization rate (balance growing toward the limit)
+- Declining payment ratio (paying less of the statement balance each month)
+- Increased cash advance usage
+- New derogatory marks on bureau (missed payments on other obligations)
+- Behavioral change — sudden large transactions or sudden spend cessation
+
+Proactive interventions:
+
+- Soft credit line reductions (reducing available credit to limit exposure)
+- Outbound contact to understand the customer's situation
+- Hardship program offers before the account goes delinquent
+
+The earlier an at-risk account is identified, the more options are available — and the lower the eventual loss.
+
+## Stage 5: Delinquency & Collections
+
+An account is delinquent when a payment is missed. Delinquency is typically tracked in buckets:
+
+- **1–29 DPD** (days past due): early stage, highest cure probability
+- **30–59 DPD**: mild delinquency
+- **60–89 DPD**: serious delinquency
+- **90–119 DPD**: severely delinquent
+- **120+ DPD**: pre-charge-off
+
+**Roll rates** measure the percentage of accounts that move from one delinquency bucket to the next in a given period. A rising 30→60 roll rate is an early warning that credit quality is deteriorating.
+
+**Cure rates** measure the percentage that recover from delinquency to current status. Early buckets cure at 40–70%; deep delinquency cures at 10–20%.
+
+Collections strategy is segmented by risk and economics. High-balance accounts in early delinquency get intensive outreach. Low-balance accounts deep in delinquency may go straight to third-party collections or settlement.
+
+## Stage 6: Charge-Off & Recovery
+
+**Charge-off** is an accounting event: the bank writes the uncollected balance off its books as a loss. This typically happens at 180 DPD (6 months past due), though the account does not disappear — collection efforts continue.
+
+Post-charge-off recovery options:
+
+- **Internal collections** — continued outreach by the bank's own team
+- **Debt sale** — selling the charged-off portfolio to a debt buyer at pennies on the dollar
+- **Third-party collections** — outsourcing recovery while retaining ownership
+
+Recovery rates on charged-off balances vary widely: 15–40% for well-managed portfolios, lower for older or previously worked debt.
+
+## Stage 7: Dormancy & Reactivation
+
+Accounts that stop generating transactions but remain open are dormant (hibernators from Part 2). Reactivation is cheaper than new acquisition.
+
+Reactivation tactics:
+
+- Targeted offers with spending incentives ("earn 5x points on your next purchase")
+- Category-relevant promotions based on past spend history
+- Personalized messaging referencing the account's history
+
+Not all dormant accounts are worth reactivating. Accounts dormant due to negative experiences or competitive displacement may require a product improvement — not just a promotion.
+
+The lifecycle does not always follow this linear path. Many accounts cycle between active usage, mild delinquency, and recovery multiple times. Lifecycle management is the ongoing work of steering accounts toward the right outcomes at every stage.
+
+In Part 4, you will see the metrics framework that lets you measure what is actually happening across the entire lifecycle.

--- a/_posts/credit-card-portfolio/2026-04-02-4-portfolio-metrics.md
+++ b/_posts/credit-card-portfolio/2026-04-02-4-portfolio-metrics.md
@@ -1,0 +1,131 @@
+---
+layout: post
+title: "Portfolio Metrics: What to Measure at Every Stage"
+subtitle: "The KPI framework for managing a credit card book from acquisition to charge-off"
+tags: [credit-card, portfolio-management]
+comments: true
+math: true
+series: "Credit Card Portfolio Management 101"
+series_part: 4
+---
+
+A credit card portfolio generates enormous amounts of data. The challenge is not measuring everything — it is knowing which metrics matter, when they matter, and what they tell you. This part builds the complete measurement framework across the lifecycle.
+
+## Acquisition Metrics
+
+**Approval rate** — the percentage of applications that result in an approved account.
+
+$$
+\text{Approval Rate} = \frac{\text{Approved Applications}}{\text{Total Applications}}
+$$
+
+Approval rate is a policy output, not a target. Moving it requires changing underwriting criteria with direct consequences for future credit quality.
+
+**Booking rate** — the percentage of approvals that result in an activated, funded account. Applicants sometimes abandon after approval.
+
+**Yield-on-book** — the weighted average APR of newly booked accounts. A leading indicator of future interest income potential.
+
+**New user vs repeated user split** — a critical segmentation at the application level:
+
+- **New user**: an applicant who has never held a credit card from any issuer. Thin-file or no-file on the bureau. Higher uncertainty on credit behavior; requires more conservative underwriting or alternative data.
+- **Repeated user**: an applicant with prior card history — either from this issuer or from others. Observable credit behavior allows more precise risk assessment.
+
+The new/repeated mix affects average approval rates, average APRs, and the shape of the loss curve. A portfolio growing predominantly through new users will see higher early-vintage losses; repeated users typically have more predictable default patterns.
+
+## Activation & Usage Metrics
+
+**Activation rate** — percentage of booked accounts that make at least one purchase within the defined activation window (typically 30, 60, or 90 days).
+
+**Active rate** — percentage of open accounts with at least one transaction in the trailing 30 days. A portfolio-level health indicator.
+
+**Purchase volume** — total spend across the portfolio per period. Drives interchange income.
+
+**Spend per active account** — average spend among accounts that made at least one transaction. Separates engagement quality from activation quantity.
+
+**Utilization rate** — balance as a percentage of credit limit.
+
+$$
+\text{Utilization Rate} = \frac{\text{Outstanding Balance}}{\text{Credit Limit}}
+$$
+
+At the portfolio level, average utilization indicates how much of the committed credit exposure is drawn. Rising utilization can signal increased revenue OR increased credit stress — context determines the interpretation.
+
+## Revenue Metrics
+
+**Net Interest Margin (NIM)** — the spread between yield earned on balances and cost of funds.
+
+$$
+\text{NIM} = \text{Yield on Receivables} - \text{Cost of Funds}
+$$
+
+**Revenue per active account** — total net revenue (interest + interchange + fees − fraud losses − rewards cost) divided by active account count. The cleanest per-unit revenue measure.
+
+**Interchange income rate** — interchange dollars as a percentage of purchase volume. Tracks the effective interchange yield of the portfolio.
+
+## Credit Quality Metrics
+
+**Delinquency rate** — percentage of accounts or balances in each DPD bucket at a point in time.
+
+$$
+\text{Delinquency Rate (30+ DPD)} = \frac{\text{Balances 30+ Days Past Due}}{\text{Total Balances}}
+$$
+
+Track both account-based and balance-based delinquency — a small number of high-balance accounts can skew the balance view.
+
+**Roll rate** — percentage of accounts in delinquency bucket X that move to bucket X+1 in the next period.
+
+$$
+\text{Roll Rate}_{30 \to 60} = \frac{\text{Accounts that were 30 DPD last month and are now 60 DPD}}{\text{Accounts that were 30 DPD last month}}
+$$
+
+Roll rates are the most sensitive early warning metric for credit deterioration.
+
+**Net charge-off (NCO) rate** — annualized net write-offs as a percentage of average outstanding balances.
+
+$$
+\text{NCO Rate} = \frac{\text{Gross Charge-offs} - \text{Recoveries}}{\text{Average Receivables}} \times \frac{12}{\text{Months}}
+$$
+
+**Delinquency rate by cohort (vintage analysis)** — instead of tracking delinquency at a point in time across the entire portfolio, cohort analysis tracks accounts by their origination month and measures their cumulative bad rate at each month of age.
+
+This is critical for detecting policy change impact. If underwriting was loosened in January, a cross-sectional delinquency rate may not show the problem for 6–12 months — but a vintage view will show the January cohort's bad rate diverging from prior cohorts at 3–6 months of age. Early identification, before losses materialize at scale.
+
+## Efficiency Metrics
+
+**Cost per account** — total operating cost (servicing, technology, compliance, collections) divided by open accounts.
+
+**Collections recovery rate** — dollars recovered as a percentage of delinquent or charged-off balances worked. Measures collections effectiveness.
+
+**Collections cost per dollar recovered** — unit economics of the collections function.
+
+## Profitability Metrics
+
+**Return on assets (ROA)** — net income as a percentage of average receivables. The primary portfolio-level profitability measure in card management.
+
+$$
+\text{ROA} = \frac{\text{Net Income}}{\text{Average Receivables}}
+$$
+
+Industry benchmarks: top-quartile portfolios achieve 3–5% ROA; mass-market portfolios typically target 2–3%.
+
+**Economic profit** — profit after deducting the cost of equity capital allocated to the portfolio. An account with positive accounting profit but negative economic profit is destroying shareholder value.
+
+**Customer lifetime value (LTV)** — present value of all future net cash flows from a customer relationship.
+
+$$
+\text{LTV} = \sum_{t=1}^{T} \frac{\text{Net Revenue}_t - \text{Expected Loss}_t - \text{Servicing Cost}_t}{(1 + r)^t}
+$$
+
+LTV is the theoretically correct basis for acquisition spend, credit limit decisions, and retention investments. In practice it requires assumptions about tenure and behavior migration, but even simplified versions improve decision quality.
+
+## The Portfolio Dashboard
+
+A well-run portfolio is monitored through a tiered dashboard:
+
+- **Weekly** — early warning signals: roll rates, DPD buckets, fraud spike, approval rate
+- **Monthly** — full P&L drivers: NIM, NCO rate, active rate, spend per account, vintage delinquency
+- **Quarterly** — strategic view: ROA, LTV by segment, cohort performance vs prior vintages, competitive benchmarks
+
+No single metric tells the whole story. The combination — revenue, utilization, delinquency, and profitability together — gives the full picture of portfolio health.
+
+In Part 5, you will see how these metrics translate into actionable management strategies across the lifecycle.

--- a/_posts/credit-card-portfolio/2026-04-02-5-management-strategies.md
+++ b/_posts/credit-card-portfolio/2026-04-02-5-management-strategies.md
@@ -1,0 +1,108 @@
+---
+layout: post
+title: "Portfolio Management Strategies"
+subtitle: "The levers that drive profitability, control risk, and extend account relationships"
+tags: [credit-card, portfolio-management]
+comments: true
+math: true
+series: "Credit Card Portfolio Management 101"
+series_part: 5
+---
+
+Metrics tell you what is happening. Strategies are what you do about it. Credit card portfolio management has a well-defined toolkit of interventions across the lifecycle — from credit line adjustments to collections segmentation to vintage-level stress testing.
+
+## Credit Line Management (CLM)
+
+The credit limit is the most direct lever an issuer controls. CLM decisions happen continuously, triggered by behavioral signals and portfolio targets.
+
+**Credit line increases (CLI)** — issued to accounts showing strong payment behavior, low utilization, and growing spend. CLIs serve two purposes: capturing more spend share from high-value customers, and improving customer satisfaction. Risk: customers may draw down the increased limit in a stress scenario.
+
+$$
+\text{CLI trigger: Utilization} < 30\%,\ \text{12+ months on-book, 0 delinquency}
+$$
+
+**Credit line decreases (CLD)** — issued to accounts showing stress signals: rising utilization, declining payment ratios, bureau deterioration. CLDs reduce the bank's maximum exposure before a loss event. Risk: can damage the customer relationship and accelerate attrition.
+
+**Account blocking** — suspending purchase authorization for accounts in serious delinquency or with fraud flags. Prevents additional exposure accumulation on a deteriorating account.
+
+CLM decisions must be made carefully: a CLD that feels prudent at the portfolio level can trigger a customer complaint or regulatory scrutiny if not applied consistently and with documented rationale.
+
+## Pricing & APR Strategy
+
+**Risk-based pricing** sets APR at origination based on estimated default probability. Higher-risk borrowers pay higher rates to compensate for expected losses.
+
+**Rate re-pricing** — adjusting the APR of existing accounts based on current behavior or market conditions. Most card agreements allow the issuer to change APR with 45 days' notice (under CARD Act rules). Re-pricing revolvers upward increases NIM; re-pricing creditworthy customers downward can improve retention.
+
+**Balance transfer pricing** — competitive rates offered to attract balance transfers from other issuers. The economics depend on the expected duration the balance remains and whether the customer becomes an engaged full-relationship customer.
+
+Pricing strategy directly determines the revolver segment's profitability and the portfolio's NIM trajectory.
+
+## Spend Stimulation
+
+Active accounts that spend more generate more interchange and are more likely to remain engaged.
+
+**Targeted offers** — personalized promotions based on spend history. A customer who frequently shops at grocery stores responds better to a grocery bonus offer than a generic 1x points promotion.
+
+**Merchant-funded rewards** — offers co-funded by merchants to drive traffic. The issuer earns a placement fee; the customer gets a relevant offer; the merchant gets incremental sales. Zero net rewards cost to the issuer.
+
+**Category activation** — bonus earn rates on categories where the card is not the primary payment method. Moves the card from "secondary spend" to "primary spend" in that category.
+
+Spend stimulation is most effective on the borderline between transactor and light revolver — customers who are engaged enough to respond but not yet deeply tied to the product.
+
+## Early Risk Intervention
+
+Waiting until an account misses a payment to intervene is expensive. Proactive risk management acts on signals before delinquency.
+
+**Behavioral triggers** — automated rules that fire when an account crosses a risk threshold: utilization above 80%, payment ratio declining three months in a row, new derogatory on bureau.
+
+**Proactive outreach** — calling or messaging at-risk customers before they miss a payment. Framed as a service call, not a collections call. Offering hardship programs, payment deferral, or rate relief before the customer is in crisis.
+
+**Soft CLDs** — reducing the credit limit on stressed accounts to cap exposure without blocking the account. The customer retains the ability to use the card; the bank limits how much it could lose.
+
+Early intervention economics are compelling: preventing one charge-off saves far more than the cost of an outreach campaign.
+
+## Collections Strategy
+
+When prevention fails and accounts go delinquent, collections strategy determines the loss outcome.
+
+**Segmentation by risk and balance** — not all delinquent accounts warrant the same investment. High-balance, early-delinquency accounts with strong prior payment history get intensive personalized outreach. Low-balance, deeply delinquent accounts with no prior payments may go straight to automated messaging or agency placement.
+
+**Channel mix** — collections can use outbound calls, SMS, email, in-app notifications, and letters. Channel effectiveness varies by customer segment and delinquency stage. Regulatory requirements constrain contact frequency and timing.
+
+**Settlement and hardship** — offering to accept less than the full balance owed in exchange for immediate payment, or structuring a payment plan. Settlement economics: accepting 50 cents on the dollar on a $5,000 account produces $2,500 recovery vs the ~$750 a debt buyer might pay (15 cents on the dollar). Internal settlement is usually the better economic outcome.
+
+**Agency placement and debt sale** — at deep delinquency (120–180 DPD) or post-charge-off, accounts can be placed with third-party collection agencies (contingency fee model) or sold outright to debt buyers. Debt sales generate immediate cash recovery and remove the collection burden; placement preserves upside if recoveries are high.
+
+## Retention & Reactivation
+
+**Voluntary attrition** — customers who proactively close or stop using their account — is a direct loss of future revenue. Retention programs address this.
+
+Retention interventions:
+
+- Renewal incentives at annual fee billing (bonus rewards to justify the fee)
+- Competitive APR offers for revolvers considering balance transfers elsewhere
+- Win-back campaigns for recently closed accounts
+
+**Reactivation** — for dormant accounts, targeted offers with a clear value proposition. The economics favor reactivation over new acquisition: no underwriting cost, no credit line setup, no physical card issuance (the card already exists).
+
+Success rates on reactivation campaigns are typically 5–15% — low in absolute terms, but with near-zero marginal cost, the ROI is high.
+
+## Portfolio-Level Stress Testing & Vintage Analysis
+
+**Vintage analysis** tracks cohorts by origination month and plots their loss performance over time. Each "vintage" produces a loss curve: cumulative net charge-off rate at 6, 12, 18, 24 months of age.
+
+Comparing vintages reveals policy changes: a vintage that curves upward faster than its predecessors at the same age signals that the origination quality of that cohort is worse — and that future losses are coming.
+
+**Stress testing** asks: what happens to the portfolio if unemployment rises 2 percentage points, or if interest rates spike, or if a specific industry sector experiences a downturn?
+
+Stress testing inputs:
+
+- Macro scenario assumptions (GDP, unemployment, rates)
+- Behavioral response assumptions (how roll rates change under stress)
+- Loss distribution modeling
+
+Outputs inform capital adequacy, loss reserve requirements, and whether the current underwriting posture is appropriate for the macro environment.
+
+Together, vintage analysis and stress testing are the most powerful tools for forward-looking portfolio management — seeing the problems before they arrive on the P&L.
+
+In Part 6, you will go deeper into the analytical models that power these strategies: scoring, cohort modeling, CLTV, and the quantitative foundations of portfolio risk.

--- a/_posts/credit-card-portfolio/2026-04-02-6-risk-models-analytics.md
+++ b/_posts/credit-card-portfolio/2026-04-02-6-risk-models-analytics.md
@@ -1,0 +1,122 @@
+---
+layout: post
+title: "Risk Models & Analytics"
+subtitle: "Scoring, vintage analysis, roll rates, and CLTV — the quantitative foundation of portfolio management"
+tags: [credit-card, portfolio-management]
+comments: true
+math: true
+series: "Credit Card Portfolio Management 101"
+series_part: 6
+---
+
+The strategies in Part 5 work because they are backed by models. Scoring tells you who to approve and at what terms. Vintage analysis tells you whether your approvals were good decisions. Roll rate analysis tells you where the portfolio is heading. CLTV tells you what a customer relationship is actually worth. This part covers the analytical infrastructure that makes portfolio management rigorous.
+
+## Application Scoring vs Behavioral Scoring
+
+### Application Scoring
+
+Applied at origination. Uses bureau data, application attributes, and (where available) internal bank data to produce a probability of default estimate.
+
+$$
+P(\text{Default}) = f(\text{bureau score, income, DTI, derogatory history, ...})
+$$
+
+The output — a scorecard or model score — drives the approve/decline decision and APR assignment. Key properties:
+
+- Built on historical applicant performance data
+- Validated on out-of-time samples to prevent overfitting
+- Must be monitored for population shift (the scorecard was built on customers from 2 years ago; today's applicants may be different)
+
+### Behavioral Scoring
+
+Applied to existing accounts on a rolling basis (monthly or more frequently). Uses internal transaction data — payment behavior, utilization trends, spend patterns, bureau refreshes — to produce an updated risk estimate for each account.
+
+Behavioral scores are more predictive than application scores for existing accounts because they incorporate actual payment behavior. A customer with a mediocre application score who has paid on time for 24 months is a very different risk than their score at origination implied.
+
+Use cases:
+
+- Trigger for CLIs or CLDs
+- Early risk intervention targeting
+- Collections prioritization
+- Retention offer eligibility
+
+## Vintage Analysis
+
+A vintage is a cohort of accounts originated in the same time period (typically the same month). Tracking each vintage's performance separately — rather than mixing all accounts together — isolates the effect of origination conditions and policy changes.
+
+**Vintage loss curve** plots cumulative net charge-off rate (vertical axis) against months on book (horizontal axis) for each origination month.
+
+Key properties:
+
+- Loss curves are typically "S-shaped": low losses early (accounts too new to default), rising sharply at 12–24 months of age, then flattening as the remaining population stabilizes
+- Comparing vintages at the same age reveals quality differences: a vintage that reaches 4% cumulative loss at month 12 vs. prior vintages at 2.5% is a clear deterioration signal
+- Policy changes leave a visible signature: if underwriting was loosened in March, the March vintage will show a steeper curve than February and January
+
+Vintage analysis answers: "Were the accounts we booked in that period good decisions?"
+
+## Roll Rate Analysis
+
+Roll rate analysis tracks the flow of accounts between delinquency states over time. It is the most sensitive real-time signal of portfolio deterioration.
+
+Define states: Current (C), 1–29 DPD, 30–59 DPD, 60–89 DPD, 90–119 DPD, 120+ DPD, Charged-Off (CO), Cured.
+
+$$
+\text{Roll Rate}_{i \to j} = \frac{N_{j,\ t+1} \text{ that were in state } i \text{ at time } t}{N_{i,\ t}}
+$$
+
+A roll rate matrix, observed monthly, produces a transition probability matrix. When roll rates are stable, the matrix can be used to project future delinquency levels and loss estimates.
+
+When roll rates spike — particularly the 30→60 and 60→90 transitions — it signals that current delinquent accounts are not curing and are progressing toward charge-off. A 5-point increase in the 30→60 roll rate translates directly into higher NCO rates 3–4 months forward.
+
+Roll rate analysis also powers loss reserve calculations (CECL in the US requires forward-looking loss estimates).
+
+## Customer Lifetime Value Modeling
+
+CLTV estimates the present value of net cash flows expected over the life of a customer relationship.
+
+$$
+\text{CLTV} = \sum_{t=1}^{T} \frac{[\text{Revenue}_t - \text{Expected Loss}_t - \text{Variable Cost}_t] \times P(\text{Active}_t)}{(1+r)^t}
+$$
+
+Where:
+
+- $T$ = expected relationship tenure
+- $P(\text{Active}_t)$ = probability the customer remains active at time $t$ (accounts for attrition and default)
+- $r$ = discount rate (hurdle rate or WACC)
+
+CLTV is used to:
+
+- Set maximum acquisition cost per segment (CAC < CLTV)
+- Size retention investment (worth spending up to the NPV of at-risk future cash flows)
+- Prioritize CLI decisions (higher-CLTV accounts justify larger credit line investments)
+- Compare profitability across products and channels
+
+Building a robust CLTV model requires assumptions about tenure distributions, revenue trajectories, loss rates by behavioral state, and discount rates. Even a simplified model — with conservative assumptions — substantially improves decision quality over flat per-account heuristics.
+
+## Stress Testing & Scenario Planning
+
+Stress testing asks: how does portfolio performance change under adverse macro conditions?
+
+**Top-down approach**: Apply macroeconomic sensitivities derived from historical regressions. For example: for every 1-point rise in unemployment, roll rates increase by X basis points and charge-off rates rise by Y.
+
+**Bottom-up approach**: Apply behavioral assumptions at the account level (probability of segment migration under stress) and aggregate up.
+
+A well-structured stress test produces:
+
+- A "base case" projection (current trajectory)
+- A "moderate stress" scenario (recession-like conditions)
+- A "severe stress" scenario (deep recession, e.g., GFC or COVID shock)
+
+Each scenario outputs projected NCO rate, revenue compression, and capital consumption over a 12–24 month horizon.
+
+Stress test outputs inform:
+
+- Loss reserves (ALLL/CECL)
+- Capital adequacy planning (regulatory and internal)
+- Underwriting tightening decisions ("if this scenario materializes, do we have enough capital to absorb it?")
+
+---
+
+The analytical models in this part — scoring, vintage analysis, roll rates, CLTV, stress testing — are the connective tissue between the raw data a portfolio generates and the decisions a portfolio manager needs to make.
+
+Together, the six parts of this series give you a complete framework for credit card portfolio management: from the economics of the product, through customer segmentation and lifecycle dynamics, to the metrics and strategies that drive outcomes, and the analytical models that make it rigorous.


### PR DESCRIPTION
Introduce a six-part series 'Credit Card Portfolio Management 101' by adding six new posts (_posts/credit-card-portfolio/2026-04-02-1...6-*.md) covering product economics, customer segmentation, lifecycle management, portfolio metrics, management strategies, and risk models & analytics. Also update _config.yml to include the series in home_series so it surfaces on the homepage.