### PR TITLE
Add series feature, pages, and homepage cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,15 @@ Both tools run in isolated environments managed by pre-commit, so you don't need
 
 ```plaintext
 .
-├── _config.yml           # Site configuration
-├── _posts/               # Blog posts
-├── _layouts/             # Page layouts
+├── _config.yml           # Site configuration (includes home_series order)
+├── _posts/               # Blog posts (organized in subdirectories by series)
+├── _layouts/             # Page layouts (includes series.html for series pages)
 ├── _includes/            # Reusable components
-├── _data/                # Data files
 ├── assets/               # Static assets (CSS, JS, images)
+├── series/               # Series index pages (one .md file per series)
 ├── aboutme.md            # About page
 ├── tags.html             # Tags page
-└── index.html            # Homepage
+└── index.html            # Homepage (shows series cards)
 ```
 
 ## Writing a New Post
@@ -134,6 +134,8 @@ Both tools run in isolated environments managed by pre-commit, so you don't need
     layout: post
     title: Your Post Title
     subtitle: Optional subtitle
+    series: "Series Name"
+    series_part: 1
     tags: [tag1, tag2]
     comments: true
     ---
@@ -142,6 +144,29 @@ Both tools run in isolated environments managed by pre-commit, so you don't need
 3. Write your content in Markdown below the front matter.
 
 4. Commit and push to GitHub. The site will automatically rebuild.
+
+## Adding a New Series
+
+1. Create a new file in `series/` (e.g., `series/my-series.md`):
+
+    ```yaml
+    ---
+    layout: series
+    title: "My Series"
+    series_name: "My Series"
+    description: "A short description of the series."
+    permalink: /series/my-series/
+    ---
+    ```
+
+2. Add the series name to `home_series` in `_config.yml` to control display order on the homepage:
+
+    ```yaml
+    home_series:
+      - "My Series"
+    ```
+
+3. Tag posts with `series: "My Series"` and `series_part: N` in their front matter.
 
 ## Configuration
 

--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ author: Urek Mazino
 ###############################################
 
 navbar-links:
+  caketool: "caketool"
+  DE Blog: "jaffle-shop"
   About Me: "aboutme"
 
 ################
@@ -106,9 +108,9 @@ feed_show_tags: true
 # Order in this list is the exact render order on home.
 # Leave empty to show all series (alphabetical by series name).
 home_series:
+  - "Credit Card Portfolio Management 101"
   - "Book Sharing"
   - "A/B Testing"
-  - "Credit Card Portfolio Management 101"
 
 # Add a search button to the navbar
 post_search: true

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -1,0 +1,36 @@
+---
+layout: page
+---
+
+<style>
+  .intro-header .page-heading h1 { font-size: 2.2rem; }
+  @media (min-width: 768px) {
+    .intro-header .page-heading h1 { font-size: 2.5rem; }
+  }
+</style>
+
+{% if page.description %}
+  <p class="lead">{{ page.description }}</p>
+{% endif %}
+
+{% assign series_posts = site.posts | where: "series", page.series_name | sort: "series_part" %}
+
+<div class="series-post-list">
+  {% for post in series_posts %}
+    <div class="series-post-entry">
+      <div class="series-post-meta">
+        {% if post.series_part %}
+          <span class="series-part-badge">Part {{ post.series_part }}</span>
+        {% endif %}
+      </div>
+      <div class="series-post-content">
+        <h3 class="series-post-title">
+          <a href="{{ post.url | relative_url }}">{{ post.title | strip_html }}</a>
+        </h3>
+        {% if post.subtitle %}
+          <p class="series-post-subtitle">{{ post.subtitle | strip_html }}</p>
+        {% endif %}
+      </div>
+    </div>
+  {% endfor %}
+</div>

--- a/assets/css/beautifuljekyll.css
+++ b/assets/css/beautifuljekyll.css
@@ -1118,3 +1118,141 @@ pre {
     display: inline-block;
   }
 }
+
+/* --- Series card grid (home page) --- */
+
+.series-card-grid {
+  margin-top: 1.5rem;
+}
+
+.series-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e9ecef;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  overflow: hidden;
+}
+
+.series-card:hover {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.series-card-body {
+  flex: 1;
+  padding: 1.5rem 1.5rem 1rem;
+}
+
+.series-card-icon {
+  font-size: 1.5rem;
+  color: {{ site.link-col | default: "#008AFF" }};
+  margin-bottom: 0.75rem;
+}
+
+.series-card-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: {{ site.text-col | default: "#404040" }};
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
+
+.series-card-desc {
+  font-size: 0.95rem;
+  color: #6c757d;
+  line-height: 1.6;
+  margin-bottom: 0;
+}
+
+.series-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #f8f9fa;
+  border-top: 1px solid #e9ecef;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
+
+.series-post-count {
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
+.series-card-link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: {{ site.link-col | default: "#008AFF" }};
+  text-decoration: none;
+}
+
+.series-card-link:hover {
+  color: {{ site.hover-col | default: "#0085A1" }};
+  text-decoration: underline;
+}
+
+/* --- Series page post listing --- */
+
+.series-post-list {
+  margin-top: 1rem;
+}
+
+.series-post-entry {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid #eee;
+  align-items: flex-start;
+}
+
+.series-post-entry:last-child {
+  border-bottom: 0;
+}
+
+.series-post-meta {
+  flex-shrink: 0;
+  padding-top: 0.2rem;
+}
+
+.series-part-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: {{ site.link-col | default: "#008AFF" }};
+  background: #e8f4ff;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  min-width: 3.5rem;
+  text-align: center;
+}
+
+.series-post-content {
+  flex: 1;
+}
+
+.series-post-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-top: 0;
+  margin-bottom: 0.2rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
+
+.series-post-title a {
+  color: {{ site.text-col | default: "#404040" }};
+  text-decoration: none;
+}
+
+.series-post-title a:hover {
+  color: {{ site.hover-col | default: "#0085A1" }};
+}
+
+.series-post-subtitle {
+  font-size: 0.9rem;
+  color: #6c757d;
+  margin-bottom: 0;
+}

--- a/index.html
+++ b/index.html
@@ -2,47 +2,52 @@
 layout: page
 ---
 
-{% assign all_grouped_series = site.posts | where_exp: "post", "post.series" | group_by: "series" %}
-{% assign grouped_series = "" | split: "" %}
+{% assign all_grouped = site.posts | where_exp: "post", "post.series" | group_by: "series" %}
+
+{% assign ordered_series = "" | split: "" %}
 {% if site.home_series and site.home_series.size > 0 %}
-	{% for series_name in site.home_series %}
-		{% assign matched_series = all_grouped_series | where: "name", series_name %}
-		{% if matched_series.size > 0 %}
-			{% assign grouped_series = grouped_series | concat: matched_series %}
-		{% endif %}
-	{% endfor %}
+  {% for series_name in site.home_series %}
+    {% assign matched = all_grouped | where: "name", series_name %}
+    {% if matched.size > 0 %}
+      {% assign ordered_series = ordered_series | concat: matched %}
+    {% endif %}
+  {% endfor %}
 {% else %}
-	{% assign grouped_series = all_grouped_series | sort: "name" %}
+  {% assign ordered_series = all_grouped | sort: "name" %}
 {% endif %}
 
-{% if grouped_series.size > 0 %}
-	{%- for series in grouped_series -%}
-		<a href="#{{- series.name -}}" class="btn btn-primary tag-btn">
-			<i class="fas fa-book" aria-hidden="true"></i>&nbsp;{{- series.name -}}&nbsp;({{ series.items.size }})
-		</a>
-	{%- endfor -%}
+{% if ordered_series.size > 0 %}
+  <div class="series-card-grid row">
+    {% for series_group in ordered_series %}
 
-	<div id="full-series-list">
-	{%- for series in grouped_series -%}
-		<h2 id="{{- series.name -}}" class="linked-section">
-			<i class="fas fa-book" aria-hidden="true"></i>
-			&nbsp;{{- series.name -}}&nbsp;({{ series.items.size }})
-		</h2>
-		<div class="post-list">
-			{%- assign series_posts = series.items | sort: "series_part" -%}
-			{%- for post in series_posts -%}
-				<div class="tag-entry">
-					<a href="{{ post.url | relative_url }}">
-						{%- if post.series_part -%}
-							Part {{ post.series_part }}:&nbsp; 
-						{%- endif -%}
-						{{- post.title | strip_html -}}
-					</a>
-				</div>
-			{%- endfor -%}
-		</div>
-	{%- endfor -%}
-	</div>
+      {% assign series_page = site.pages | where: "series_name", series_group.name | first %}
+
+      <div class="col-md-6 col-lg-4 mb-4">
+        <div class="series-card h-100">
+          <div class="series-card-body">
+            <div class="series-card-icon">
+              <i class="fas fa-book-open" aria-hidden="true"></i>
+            </div>
+            <h3 class="series-card-title">{{ series_group.name }}</h3>
+            {% if series_page.description %}
+              <p class="series-card-desc">{{ series_page.description }}</p>
+            {% endif %}
+          </div>
+          <div class="series-card-footer">
+            <span class="series-post-count">
+              {{ series_group.items.size }} post{% if series_group.items.size != 1 %}s{% endif %}
+            </span>
+            {% if series_page %}
+              <a href="{{ series_page.url | relative_url }}" class="series-card-link">
+                Read series &rarr;
+              </a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+    {% endfor %}
+  </div>
 {% else %}
-	<p>No series found yet. Add <code>series</code> and <code>series_part</code> to post front matter to organize posts here.</p>
+  <p>No series found yet. Add <code>series</code> and <code>series_part</code> to post front matter to organize posts here.</p>
 {% endif %}

--- a/series/ab-testing.md
+++ b/series/ab-testing.md
@@ -1,0 +1,7 @@
+---
+layout: series
+title: "A/B Testing"
+series_name: "A/B Testing"
+description: "A practical guide to running rigorous experiments — from statistical foundations through pitfalls and decision frameworks."
+permalink: /series/ab-testing/
+---

--- a/series/book-sharing.md
+++ b/series/book-sharing.md
@@ -1,0 +1,7 @@
+---
+layout: series
+title: "Book Sharing"
+series_name: "Book Sharing"
+description: "Key insights and summaries from books worth reading."
+permalink: /series/book-sharing/
+---

--- a/series/credit-card-portfolio.md
+++ b/series/credit-card-portfolio.md
@@ -1,0 +1,7 @@
+---
+layout: series
+title: "Credit Card Portfolio Management 101"
+series_name: "Credit Card Portfolio Management 101"
+description: "How credit card products work, how portfolios are built, and how risk is managed from first principles."
+permalink: /series/credit-card-portfolio/
+---


### PR DESCRIPTION
Introduce a series feature for the site: add a new series layout (/_layouts/series.html) that lists posts by series and sorts by series_part; add CSS for series cards and series page styling (assets/css/beautifuljekyll.css); update index.html to render series as card tiles on the homepage and respect site.home_series ordering; add three example series pages (series/ab-testing.md, series/book-sharing.md, series/credit-card-portfolio.md). Also update README.md with instructions for adding series and example front matter, and adjust _config.yml navbar links. This enables curated series pages and a nicer homepage presentation of multi-part posts.